### PR TITLE
Setting initial state to 'processing'

### DIFF
--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -1,2 +1,9 @@
 class Document < ApplicationRecord
+  before_create :set_initial_state
+
+  private
+
+  def set_initial_state
+    self.state = 'processing'
+  end
 end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -1,4 +1,21 @@
 require 'rails_helper'
 
 RSpec.describe Document, type: :model do
+
+  describe 'set_initial_state' do
+    let(:document) { create(:document) }
+
+    context 'when the record is first created' do
+      it 'should set state to processing' do
+        expect(document.state).to eq 'processing'
+      end
+    end
+
+    context 'when the record is updated' do
+      it 'should not change the state' do
+        document.update_attributes(state: 'safe')
+        expect(document.state).to_not eq 'processing'
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added a callback to the document model that sets the state to 'processing' when an object is first created.