### PR TITLE
Feature/con 676 move request to bg

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,6 +76,7 @@ group :test do
   gem 'faker'
   gem 'database_cleaner'
   gem 'webmock'
+  gem 'rspec-sidekiq'
   gem 'simplecov', '0.20', require: false
   gem 'climate_control'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -43,6 +43,9 @@ gem 'figaro', '~> 1.2.0'
 # Exception tracking
 gem 'rollbar', '~> 3.1.1'
 
+# Sidekiq - using an older version that works with redis v3.2.6
+gem 'sidekiq', '~> 5.0.0.rc1'
+
 # Environment variables management
 gem 'vault', '~> 0.15.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,6 +91,7 @@ GEM
       carrierwave (~> 2.0)
     climate_control (0.2.0)
     concurrent-ruby (1.1.7)
+    connection_pool (2.2.3)
     crack (0.4.4)
     crass (1.0.6)
     database_cleaner (1.8.5)
@@ -162,6 +163,8 @@ GEM
     puma (4.3.7)
       nio4r (~> 2.0)
     rack (2.2.3)
+    rack-protection (2.1.0)
+      rack
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (6.0.3.4)
@@ -198,6 +201,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redis (4.2.5)
     regexp_parser (2.0.3)
     rexml (3.2.4)
     rollbar (3.1.1)
@@ -238,6 +242,11 @@ GEM
       ffi (~> 1.9)
     shoulda-matchers (4.4.1)
       activesupport (>= 4.2.0)
+    sidekiq (5.0.5)
+      concurrent-ruby (~> 1.0)
+      connection_pool (~> 2.2, >= 2.2.0)
+      rack-protection (>= 1.5.0)
+      redis (>= 3.3.4, < 5)
     simplecov (0.20.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -297,6 +306,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   shoulda-matchers (~> 4.4.1)
+  sidekiq (~> 5.0.0.rc1)
   simplecov (= 0.20)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,9 @@ GEM
       rspec-expectations (~> 3.9)
       rspec-mocks (~> 3.9)
       rspec-support (~> 3.9)
+    rspec-sidekiq (3.1.0)
+      rspec-core (~> 3.0, >= 3.0.0)
+      sidekiq (>= 2.4.0)
     rspec-support (3.10.0)
     rubocop (1.7.0)
       parallel (~> 1.10)
@@ -303,6 +306,7 @@ DEPENDENCIES
   rails (~> 6.0.3, >= 6.0.3.4)
   rollbar (~> 3.1.1)
   rspec-rails (~> 4.0.1)
+  rspec-sidekiq
   rubocop
   rubocop-rails
   shoulda-matchers (~> 4.4.1)

--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,0 @@
-web: rake db:migrate && bin/rails server
-worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
 web: rake db:migrate && bin/rails server
+worker: bundle exec sidekiq -C config/sidekiq.yml

--- a/app/workers/call_check_service_worker.rb
+++ b/app/workers/call_check_service_worker.rb
@@ -1,0 +1,11 @@
+class CallCheckServiceWorker
+  include Sidekiq::Worker
+  sidekiq_options retry: 5, dead: false
+
+  def perform(unchecked_document_id)
+    return unless ENV['CHECK_ENDPOINT_URL']
+
+    HTTParty.put(ENV['CHECK_ENDPOINT_URL'], body:
+      { unchecked_document_id: unchecked_document_id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+  end
+end

--- a/app/workers/call_check_service_worker.rb
+++ b/app/workers/call_check_service_worker.rb
@@ -1,6 +1,6 @@
 class CallCheckServiceWorker
   include Sidekiq::Worker
-  sidekiq_options retry: 5, dead: false
+  sidekiq_options retry: 5, dead: false, queue: :upload
 
   def perform(unchecked_document_id)
     return unless ENV['CHECK_ENDPOINT_URL']

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -1,0 +1,5 @@
+if Gem::Version.new(Sidekiq::VERSION) < Gem::Version.new('6.1')
+  Redis.exists_returns_integer = true
+else
+  raise 'Time to remove Redis.exists_returns_integer: https://github.com/mperham/sidekiq/issues/4591'
+end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,8 @@
+unless Rails.env.test? || Rails.env.development?
+  Sidekiq.configure_server do |config|
+    config.redis = { url: JSON.parse(ENV['VCAP_SERVICES'])['redis'][0]['credentials']['uri'] }
+  end
+  Sidekiq.configure_client do |config|
+    config.redis = { url: JSON.parse(ENV['VCAP_SERVICES'])['redis'][0]['credentials']['uri'] }
+  end
+end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,2 +1,4 @@
 ---
 :concurrency:  2
+:queues:
+  - upload

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,2 @@
+---
+:concurrency:  2

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,9 +1,14 @@
 ---
 applications:
   - name: ccs-conclave-document-upload
+    sidecars:
+      - name: sidekiq
+        process_types: [ 'worker' ]
+        command: bundle exec sidekiq -C config/sidekiq.yml
     services:
       - ccs-conclave-document-upload-pg-service
       - ccs-conclave-document-s3-service
+      - ccs-conclave-document-upload-redis-service
       - API_ROLLBAR
     memory: 768M
     disk_quota: 3G

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,6 +5,7 @@ applications:
       - ccs-conclave-document-upload-pg-service
       - ccs-conclave-document-s3-service
       - API_ROLLBAR
-    memory: 256M
+    memory: 768M
+    disk_quota: 2G
     buildpacks:
       - https://github.com/cloudfoundry/ruby-buildpack.git

--- a/spec/requests/document_upload_request_spec.rb
+++ b/spec/requests/document_upload_request_spec.rb
@@ -6,8 +6,6 @@ RSpec.describe 'DocumentUploads', type: :request do
   # Test suite for POST /document-upload
   describe 'POST /document-upload' do
     let(:client) { create(:client, source_app: 'evidence_locker') }
-    let(:put_response) { instance_double(HTTParty::Response, body: put_response_body) }
-    let(:put_response_body) { 'response_body' }
 
     let(:headers) do
       {
@@ -15,10 +13,6 @@ RSpec.describe 'DocumentUploads', type: :request do
         'HTTP_AUTHORIZATION' => ActionController::HttpAuthentication::Basic.encode_credentials(client.source_app,
                                                                                                client.api_key)
       }
-    end
-
-    before do
-      allow(HTTParty).to receive(:put).and_return(put_response)
     end
 
     context 'when success' do
@@ -41,10 +35,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -69,10 +62,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -97,10 +89,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -125,10 +116,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -153,10 +143,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -181,10 +170,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -209,10 +197,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -237,10 +224,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -265,10 +251,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -293,10 +278,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -321,10 +305,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -349,10 +332,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -377,10 +359,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -405,10 +386,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -433,10 +413,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -461,10 +440,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -489,10 +467,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -517,10 +494,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -545,10 +521,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -573,10 +548,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -601,10 +575,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -643,10 +616,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -672,10 +644,9 @@ RSpec.describe 'DocumentUploads', type: :request do
           end.to change(UncheckedDocument, :count).by(1)
         end
 
-        it 'does the PUT request' do
+        it 'starts the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-            { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+          expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
         end
 
         it 'returns status code 201' do
@@ -714,10 +685,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to change(UncheckedDocument, :count).by(1)
       end
 
-      it 'does the PUT request' do
+      it 'starts the check request background job' do
         post '/document-upload', params: valid_attributes, headers: headers
-        expect(HTTParty).to have_received(:put).with(ENV['CHECK_ENDPOINT_URL'], body:
-          { unchecked_document_id: UncheckedDocument.last.id }, headers: { 'Authorization' => ENV['AUTH_TOKEN'] })
+        expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(UncheckedDocument.take.id)
       end
 
       it 'returns status code 201' do
@@ -739,9 +709,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -768,9 +738,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -803,9 +773,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -851,9 +821,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -880,9 +850,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -909,9 +879,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -938,9 +908,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -967,9 +937,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -996,9 +966,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -1025,9 +995,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'starts the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -1054,9 +1024,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -1086,9 +1056,9 @@ RSpec.describe 'DocumentUploads', type: :request do
         end.to_not change(UncheckedDocument, :count)
       end
 
-      it 'does not do the PUT request' do
+      it 'does not start the check request background job' do
         post '/document-upload', params: invalid_attributes, headers: headers
-        expect(HTTParty).not_to have_received(:put)
+        expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
       end
 
       it 'returns status code 422' do
@@ -1113,24 +1083,24 @@ RSpec.describe 'DocumentUploads', type: :request do
       context 'when posting a file' do
         let(:valid_attributes) { { document_file: pdf_file, type_validation: ['pdf'], size_validation: 1000000 } }
 
-        it 'creates a Document' do
+        it 'does not create a Document' do
           expect do
             post '/document-upload', params: valid_attributes, headers: headers
           end.to change(Document, :count).by(0)
         end
 
-        it 'creates an UncheckedDocument' do
+        it 'does not create an UncheckedDocument' do
           expect do
             post '/document-upload', params: valid_attributes, headers: headers
           end.to change(UncheckedDocument, :count).by(0)
         end
 
-        it 'does not do the PUT request' do
+        it 'does not start the check request background job' do
           post '/document-upload', params: valid_attributes, headers: headers
-          expect(HTTParty).not_to have_received(:put)
+          expect(CallCheckServiceWorker).to_not have_enqueued_sidekiq_job
         end
 
-        it 'returns status code 201' do
+        it 'returns status code 401' do
           post '/document-upload', params: valid_attributes, headers: headers
           expect(response).to have_http_status(401)
         end


### PR DESCRIPTION
Moved the PUT request to the Check service to a background service in order to decrease response time and increase performance