### PR TITLE
Reverting the change to call the check service after_create

### DIFF
--- a/app/controllers/document_upload_controller.rb
+++ b/app/controllers/document_upload_controller.rb
@@ -3,6 +3,7 @@ class DocumentUploadController < ApplicationController
     unchecked_document = @client.unchecked_documents.new(document_parameters.reject { |_, v| v.blank? })
 
     if unchecked_document.save
+      CallCheckServiceWorker.perform_async(unchecked_document.id)
       render json: unchecked_document.document.to_json, status: :created
     else
       render json: unchecked_document.errors, status: :unprocessable_entity

--- a/app/models/unchecked_document.rb
+++ b/app/models/unchecked_document.rb
@@ -21,7 +21,6 @@ class UncheckedDocument < ApplicationRecord
   before_validation :add_url_protocol, if: :document_file_path
   before_validation :grab_image, if: :document_file_path
   before_validation :create_document
-  after_create :call_check_service
 
   private
 
@@ -77,9 +76,5 @@ class UncheckedDocument < ApplicationRecord
     return if document_file_path[%r{\Ahttp://}] || document_file_path[%r{\Ahttps://}]
 
     self.document_file_path = "http://#{document_file_path}"
-  end
-
-  def call_check_service
-    CallCheckServiceWorker.perform_async(id)
   end
 end

--- a/spec/models/unchecked_document_spec.rb
+++ b/spec/models/unchecked_document_spec.rb
@@ -49,17 +49,6 @@ RSpec.describe UncheckedDocument, type: :model do
         end
       end
     end
-
-    context '.call_check_service' do
-      let(:unchecked_document) do
-        create(:unchecked_document, document_file: document_file, type_validation: ['pdf'], size_validation: 1000000)
-      end
-
-      it 'starts a CallCheckServiceWorker job' do
-        unchecked_document.save
-        expect(CallCheckServiceWorker).to have_enqueued_sidekiq_job(unchecked_document.id)
-      end
-    end
   end
 
   describe 'relationship' do


### PR DESCRIPTION
Reverting the change where the check service was being called after_create. This is now getting called from the controller again. This is due to the fact that the check service was trying to process the file but the file was not there yet.